### PR TITLE
fix: race conditions in base_index and eventlogstore

### DIFF
--- a/stores/basestore/base_index.go
+++ b/stores/basestore/base_index.go
@@ -1,21 +1,28 @@
 package basestore
 
 import (
+	"sync"
+
 	ipfslog "berty.tech/go-ipfs-log"
 
 	"berty.tech/go-orbit-db/iface"
 )
 
 type baseIndex struct {
+	mu    sync.Mutex
 	id    []byte
 	index []ipfslog.Entry
 }
 
 func (b *baseIndex) Get(_ string) interface{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.index
 }
 
 func (b *baseIndex) UpdateIndex(log ipfslog.Log, entries []ipfslog.Entry) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.index = log.Values().Slice()
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: phanquy <phanhuynhquy@gmail.com>
Some race conditions:
1. In base_index : by default used in berty Message store - race condition happen when write new message and a replicate is on-going

2. In eventLogStore: when error happen in Stream() - no close channel was made, this will block List().
With this change - in case of error happen, maybe `case err := <-errChan:` will never be executed. 