### PR TITLE
API KeyValue always create a new key value store.

### DIFF
--- a/orbitdb.go
+++ b/orbitdb.go
@@ -107,7 +107,6 @@ func (o *orbitDB) KeyValue(ctx context.Context, address string, options *CreateD
 		options = &CreateDBOptions{}
 	}
 
-	options.Create = boolPtr(true)
 	options.StoreType = stringPtr("keyvalue")
 
 	store, err := o.Open(ctx, address, options)


### PR DESCRIPTION
Say we have an instance of iface.OrbitDB as `db`.
If we're intended to open an existing key value store, we can use something described as below:
```go
db.KeyValue(ctx, addr, &iface.CreateDBOptions{
    Create: boolPtr(false),
})
```
But it will always create a new database, even if we set the option `Create` to false.
The fix should be removing the code which always set `option.Create = true`