### PR TITLE
fix(replicator): alignment of atomic int64 fields

### DIFF
--- a/stores/replicator/replicator.go
+++ b/stores/replicator/replicator.go
@@ -21,20 +21,23 @@ import (
 var batchSize = 1
 
 type replicator struct {
-	events.EventEmitter
-
-	cancelFunc          context.CancelFunc
-	store               storeInterface
-	fetching            map[string]cid.Cid
+	// These require 64 bit alignment for ARM and 32bit devices
 	statsTasksRequested int64
 	statsTasksStarted   int64
 	statsTasksProcessed int64
-	buffer              []ipfslog.Log
-	concurrency         int64
-	queue               map[string]cid.Cid
-	lock                sync.RWMutex
-	logger              *zap.Logger
-	tracer              trace.Tracer
+	// For more information see https://pkg.go.dev/sync/atomic#pkg-note-BUG
+
+	events.EventEmitter
+
+	cancelFunc  context.CancelFunc
+	store       storeInterface
+	fetching    map[string]cid.Cid
+	buffer      []ipfslog.Log
+	concurrency int64
+	queue       map[string]cid.Cid
+	lock        sync.RWMutex
+	logger      *zap.Logger
+	tracer      trace.Tracer
 }
 
 func (r *replicator) GetBufferLen() int {


### PR DESCRIPTION
> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 