### PR TITLE
WIP fix: head exchange

### DIFF
--- a/baseorbitdb/orbitdb.go
+++ b/baseorbitdb/orbitdb.go
@@ -950,15 +950,17 @@ func (o *orbitDB) exchangeHeads(ctx context.Context, p p2pcore.PeerID, store Sto
 
 	o.logger.Debug(fmt.Sprintf("connected to %s", p))
 
-	untypedHeads := store.OpLog().Heads().Slice()
-	heads := make([]*entry.Entry, len(untypedHeads))
-	for i := range untypedHeads {
-		head, ok := untypedHeads[i].(*entry.Entry)
-		if !ok {
-			return nil, errors.New("unable to downcast head")
-		}
+	var heads []*entry.Entry
+	headsBytes, err := store.Cache().Get(ctx, datastore.NewKey("_localHeads"))
+	if err != nil && err != datastore.ErrNotFound {
+		return nil, errors.Wrap(err, "unable to get local heads from cache")
+	}
 
-		heads[i] = head
+	if headsBytes != nil {
+		err = json.Unmarshal(headsBytes, &heads)
+		if err != nil {
+			o.logger.Warn("unable to unmarshal cached local heads", zap.Error(err))
+		}
 	}
 
 	exchangedHeads := &exchangedHeads{

--- a/baseorbitdb/orbitdb.go
+++ b/baseorbitdb/orbitdb.go
@@ -989,7 +989,7 @@ func (o *orbitDB) exchangeHeads(ctx context.Context, p p2pcore.PeerID, store Sto
 }
 
 func (o *orbitDB) watchOneOnOneMessage(ctx context.Context, channel iface.DirectChannel, sharedKey enc.SharedKey) {
-	sub := channel.Subscribe(ctx)
+	sub := channel.GlobalChannel(ctx)
 	go func() {
 		for evt := range sub {
 			o.logger.Debug("received one on one message")

--- a/pubsub/directchannel/channel_test.go
+++ b/pubsub/directchannel/channel_test.go
@@ -33,7 +33,7 @@ func TestInitDirectChannelFactory(t *testing.T) {
 		hosts[i], err = mn.GenPeer()
 		require.NoError(t, err)
 
-		directChannelsFactories[i] = InitDirectChannelFactory(zap.NewNop(), hosts[i])
+		directChannelsFactories[i] = InitDirectChannelFactory(ctx, zap.NewNop(), hosts[i])
 	}
 
 	err = mn.LinkAll()
@@ -92,7 +92,7 @@ func TestInitDirectChannelFactory(t *testing.T) {
 				go func() {
 					defer cancel()
 
-					sub := ch2.Subscribe(ctx)
+					sub := ch2.GlobalChannel(ctx)
 					subWg.Done()
 
 					for evt := range sub {

--- a/tests/replicate_test.go
+++ b/tests/replicate_test.go
@@ -110,7 +110,7 @@ func testDirectChannelNodeGenerator(t *testing.T, mn mocknet.Mocknet, i int) (or
 
 	orbitdb1, err := orbitdb.NewOrbitDB(ctx, ipfs1, &orbitdb.NewOrbitDBOptions{
 		Directory:            &dbPath1,
-		DirectChannelFactory: directchannel.InitDirectChannelFactory(zap.NewNop(), node1.PeerHost),
+		DirectChannelFactory: directchannel.InitDirectChannelFactory(ctx, zap.NewNop(), node1.PeerHost),
 	})
 	require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func testLogAppendReplicateMultipeer(t *testing.T, amount int, nodeGen func(t *t
 		require.NoError(t, err)
 
 		stores[i] = store
-		subChans[i] = store.Subscribe(ctx)
+		subChans[i] = store.GlobalChannel(ctx)
 		defer func() { _ = store.Close() }()
 	}
 


### PR DESCRIPTION
When a peer has just been connected and has a head list ahead, it cannot exchange its head list with other already connected peers.