### PR TITLE
fix replciation when there is no direct connection betwen peers

### DIFF
--- a/iface/interface.go
+++ b/iface/interface.go
@@ -404,11 +404,13 @@ type PubSubSubscriptionOptions struct {
 // EventPubSubMessage Indicates a new message posted on a pubsub topic
 type EventPubSubMessage struct {
 	Content []byte
+	From    peer.ID
 }
 
 // EventPubSubPayload An event received on new messages
 type EventPubSubPayload struct {
 	Payload []byte
+	From    peer.ID
 }
 
 // EventPubSubJoin Is an event triggered when a peer joins the channel

--- a/pubsub/directchannel/channel.go
+++ b/pubsub/directchannel/channel.go
@@ -75,7 +75,7 @@ func (d *directChannel) handleNewPeer(s network.Stream) {
 		return
 	}
 
-	if err := d.emitter.Emit(pubsub.NewEventPayload(data)); err != nil {
+	if err := d.emitter.Emit(pubsub.NewEventPayload(data, s.Conn().RemotePeer())); err != nil {
 		d.logger.Error("unable to emit on emitter", zap.Error(err))
 	}
 }

--- a/pubsub/event.go
+++ b/pubsub/event.go
@@ -29,16 +29,18 @@ func (e *PayloadEmitter) Emit(evt *iface.EventPubSubPayload) error {
 }
 
 // Creates a new Message event
-func NewEventMessage(content []byte) *iface.EventPubSubMessage {
+func NewEventMessage(content []byte, p peer.ID) *iface.EventPubSubMessage {
 	return &iface.EventPubSubMessage{
 		Content: content,
+		From:    p,
 	}
 }
 
 // NewEventPayload Creates a new Message event
-func NewEventPayload(payload []byte) *iface.EventPubSubPayload {
+func NewEventPayload(payload []byte, p peer.ID) *iface.EventPubSubPayload {
 	return &iface.EventPubSubPayload{
 		Payload: payload,
+		From:    p,
 	}
 }
 

--- a/pubsub/oneonone/channel.go
+++ b/pubsub/oneonone/channel.go
@@ -148,7 +148,7 @@ func (c *channels) monitorTopic(sub coreapi.PubSubSubscription, p peer.ID) {
 			continue
 		}
 
-		if err := c.emitter.Emit(pubsub.NewEventPayload(msg.Data())); err != nil {
+		if err := c.emitter.Emit(pubsub.NewEventPayload(msg.Data(), msg.From())); err != nil {
 			c.logger.Warn("unable to emit event payload", zap.Error(err))
 		}
 	}

--- a/pubsub/pubsubcoreapi/pubsub.go
+++ b/pubsub/pubsubcoreapi/pubsub.go
@@ -129,7 +129,7 @@ func (p *psTopic) WatchMessages(ctx context.Context) (<-chan *iface.EventPubSubM
 				continue
 			}
 
-			ch <- pubsub.NewEventMessage(msg.Data())
+			ch <- pubsub.NewEventMessage(msg.Data(), msg.From())
 		}
 	}()
 


### PR DESCRIPTION
Scenario:
* there are 3 nodes: A, B, C
* A,B  are connected via wifi routers with automatic port forwarding NAT feature disabled
* A,B don't see each other but both connected to C

Problem reproduction:
1. A creates new store and writes 1 entry
2. C also creates store with same name and receives data from A
3. B creates same store  and doesn't receive data.  (Data will be received when A adds a new entry to store and all 3 nodes are online)

After my fix B will receive data even if A went offline




