### PR TITLE
fix: directChannel not working

### DIFF
--- a/baseorbitdb/events.go
+++ b/baseorbitdb/events.go
@@ -1,0 +1,18 @@
+package baseorbitdb
+
+import (
+	"berty.tech/go-orbit-db/iface"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type EventExchangeHeads struct {
+	Peer    peer.ID
+	Message *iface.MessageExchangeHeads
+}
+
+func NewEventExchangeHeads(p peer.ID, msg *iface.MessageExchangeHeads) EventExchangeHeads {
+	return EventExchangeHeads{
+		Peer:    p,
+		Message: msg,
+	}
+}

--- a/baseorbitdb/events_handler.go
+++ b/baseorbitdb/events_handler.go
@@ -1,0 +1,26 @@
+package baseorbitdb
+
+import (
+	"context"
+	"fmt"
+
+	ipfslog "berty.tech/go-ipfs-log"
+	"berty.tech/go-orbit-db/iface"
+)
+
+func (o *orbitDB) handleEventExchangeHeads(ctx context.Context, e *iface.MessageExchangeHeads, store iface.Store) error {
+	untypedHeads := make([]ipfslog.Entry, len(e.Heads))
+	for i, h := range e.Heads {
+		untypedHeads[i] = h
+	}
+
+	o.logger.Debug(fmt.Sprintf("%s: Received %d heads for '%s':", o.PeerID().String(), len(untypedHeads), e.Address))
+
+	if len(untypedHeads) > 0 {
+		if err := store.Sync(ctx, untypedHeads); err != nil {
+			return fmt.Errorf("unable to sync heads: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/iface/interface.go
+++ b/iface/interface.go
@@ -53,6 +53,8 @@ type CreateDBOptions struct {
 	IO                      ipfslog.IO
 	Timeout                 time.Duration
 	MessageMarshaler        MessageMarshaler
+	Logger                  *zap.Logger
+	CloseFunc               func()
 	StoreSpecificOpts       interface{}
 }
 
@@ -345,12 +347,12 @@ type NewStoreOptions struct {
 	Logger                 *zap.Logger
 	Tracer                 trace.Tracer
 	IO                     ipfslog.IO
-	StoreSpecificOpts      interface{}
 	PubSub                 PubSubInterface
 	MessageMarshaler       MessageMarshaler
 	PeerID                 peer.ID
-	DirectChannelFactory   DirectChannelFactory
-	NewHeadsEmitter        event.Emitter
+	DirectChannel          DirectChannel
+	CloseFunc              func()
+	StoreSpecificOpts      interface{}
 }
 
 type DirectChannelOptions struct {

--- a/pubsub/directchannel/channel.go
+++ b/pubsub/directchannel/channel.go
@@ -82,6 +82,7 @@ func (d *directChannel) Connect(ctx context.Context, pid peer.ID) (err error) {
 // @NOTE(gfanton): we dont need this on direct channel
 // Close Closes the connection
 func (d *directChannel) Close() error {
+	d.host.RemoveStreamHandler(PROTOCOL)
 	return d.emitter.Close()
 }
 

--- a/stores/events.go
+++ b/stores/events.go
@@ -3,7 +3,6 @@ package stores
 import (
 	ipfslog "berty.tech/go-ipfs-log"
 	"berty.tech/go-orbit-db/address"
-	"berty.tech/go-orbit-db/iface"
 	"berty.tech/go-orbit-db/stores/replicator"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p/core/peer"
@@ -16,7 +15,6 @@ var Events = []interface{}{
 	new(EventLoad),
 	new(EventReplicated),
 	new(EventReplicate),
-	new(EventExchangeHeads),
 }
 
 type EventReplicate struct {
@@ -137,18 +135,5 @@ type EventNewPeer struct {
 func NewEventNewPeer(p peer.ID) EventNewPeer {
 	return EventNewPeer{
 		Peer: p,
-	}
-}
-
-// EventExchangeHeadsset An event as stateful, sent when new exchange head is done, so newly subscriber can replay last event in case they missed it
-type EventExchangeHeads struct {
-	Peer    peer.ID
-	Message *iface.MessageExchangeHeads
-}
-
-func NewEventExchangeHeads(p peer.ID, msg *iface.MessageExchangeHeads) EventExchangeHeads {
-	return EventExchangeHeads{
-		Peer:    p,
-		Message: msg,
 	}
 }


### PR DESCRIPTION
Roll back directChannel in orbitdb instance to avoid multiple instances of directChannel sharing the same protocolID.

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>