### PR TITLE
test: wait for gossipsub topic peers before writing in replication tests

### DIFF
--- a/tests/replicate_automatically_test.go
+++ b/tests/replicate_automatically_test.go
@@ -14,6 +14,7 @@ import (
 	"berty.tech/go-orbit-db/stores/operation"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/kubo/core"
+	options "github.com/ipfs/kubo/core/coreiface/options"
 	"github.com/libp2p/go-libp2p/core/peer"
 	p2pmocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
@@ -236,6 +237,18 @@ func TestReplicateAutomatically(t *testing.T) {
 		case <-sub1.Out():
 			require.Fail(t, "Should not happen")
 		default:
+		}
+
+		// Wait until both stores have discovered each other on the pubsub topic
+		// before writing: handleEventWrite only announces a head when the topic
+		// already has peers, so writing before the gossipsub mesh has formed
+		// would silently drop the announcement and db2 would never replicate.
+		for _, store := range []orbitdb.EventLogStore{db1, db2} {
+			topic := store.Address().String()
+			require.Eventuallyf(t, func() bool {
+				peers, err := store.IPFS().PubSub().Peers(ctx, options.PubSub.Topic(topic))
+				return err == nil && len(peers) >= 1
+			}, time.Second*20, time.Millisecond*50, "store did not discover topic peer")
 		}
 
 		subCtx, subCancel := context.WithTimeout(ctx, 5*time.Second)

--- a/tests/replicate_test.go
+++ b/tests/replicate_test.go
@@ -120,6 +120,18 @@ func testLogAppendReplicate(t *testing.T, amount int, nodeGen func(t *testing.T,
 	require.NoError(t, err)
 	defer sub.Close()
 
+	// Wait until both stores have discovered each other on the pubsub topic
+	// before writing: handleEventWrite only announces a head when the topic
+	// already has peers, so writing before the gossipsub mesh has formed would
+	// silently drop the announcement and store1 would never replicate.
+	for _, store := range []orbitdb.EventLogStore{store0, store1} {
+		topic := store.Address().String()
+		require.Eventuallyf(t, func() bool {
+			peers, err := store.IPFS().PubSub().Peers(ctx, options.PubSub.Topic(topic))
+			return err == nil && len(peers) >= 1
+		}, time.Second*20, time.Millisecond*50, "store did not discover topic peer")
+	}
+
 	events := make(map[replicateEvent]int)
 	cerr := make(chan error)
 	go func() {


### PR DESCRIPTION
## Problem

After #175 (kubo v0.41.0 update), CI kept failing intermittently — but on a test that the hardening in that PR did not touch:

```
--- FAIL: TestReplicateAutomatically/automatic_replication_exchanges_the_correct_heads
    replicate_automatically_test.go: Should be true   (hasAllResults == false)
```

## Root cause

`BaseStore.handleEventWrite` only publishes a head announcement when the pubsub topic already has peers:

```go
if len(peer) > 0 {
    ... topic.Publish(...)
}   // else: the announcement is silently dropped
```

Several replication tests write immediately after connecting peers, racing gossipsub mesh formation. When a write lands before the receiving store is a known topic peer, the announcement is dropped and replication never happens — failing intermittently on slower CI runners. This is the same race that was fixed for `TestReplicationMultipeer`, just not applied to the other tests with the same pattern.

## Fix

Apply the proven `TestReplicationMultipeer` pattern to the two remaining vulnerable tests: poll each store's topic peer count and wait until peers are known before publishing.

- **`TestReplication`** (`testLogAppendReplicate`): `store0` wrote right after `ConnectAllButSelf`, so `store1` occasionally saw no `EventReplicated` and timed out.
- **`TestReplicateAutomatically/"automatic replication exchanges the correct heads"`**: `db1` wrote right after connecting, leaving `db2` unable to replicate and `hasAllResults` false until the 5s window expired. The peer-wait runs *before* the 5s replication window is opened so mesh-formation time is not counted against it.

The `"starts replicating the database when peers connect"` subtest deliberately writes while disconnected and reconnects, so it replicates via the exchange-heads-on-connect path rather than `handleEventWrite` — it is not affected and is left unchanged.

## Testing

`go vet ./tests/` clean. Ran `TestReplication` and `TestReplicateAutomatically` repeatedly — consistently green.
