### PR TITLE
test: fix replication flakes — multipeer pubsub burst loss + reconnect timeout

### DIFF
--- a/tests/pubsub_traced_test.go
+++ b/tests/pubsub_traced_test.go
@@ -1,0 +1,172 @@
+package tests
+
+// Pubsub construction for the replication tests.
+//
+// Kubo builds its internal gossipsub with the library's default queue sizes
+// (validation queue 32, per-peer outbound queue 32) and exposes no way to
+// change them or to attach a RawTracer. Those 32-slot outbound queues
+// overflow during TestReplicationMultipeer's concurrent write burst (10 peers
+// publishing 5 head announcements each, plus mesh forwarding): the publisher
+// silently drops whole RPCs (DropRPC) and never retries them, and when every
+// redundant path for an announcement (flood-publish, mesh forwarding, the
+// ~3-heartbeat IHAVE/IWANT gossip window) is lost during the congestion, the
+// head is never replicated. Tracing showed hundreds of DropRPC events per
+// node at queue size 32, with failures in ~2/15 runs, and zero drops or
+// failures at 256.
+//
+// So the test node generators build the same pubsub kubo would
+// (flood-publish + BasicSeqnoValidator) directly on the node's host, with
+// enlarged queues and a RawTracer that reports drop counters on stdout
+// whenever real loss occurs. TEST_PUBSUB_QUEUE overrides the queue size for
+// future investigation (e.g. 32 reproduces the kubo-default behavior).
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	ipfsCore "github.com/ipfs/kubo/core"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const defaultTestPubsubQueueSize = 256
+
+func testPubsubQueueSize() int {
+	if v := os.Getenv("TEST_PUBSUB_QUEUE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultTestPubsubQueueSize
+}
+
+// dropTracer counts pubsub events that imply silent message loss.
+type dropTracer struct {
+	mu            sync.Mutex
+	label         string
+	dropRPC       int
+	rejected      map[string]int // reason -> count
+	undeliverable int
+	throttled     int
+	grafts        int
+	delivered     int
+	duplicates    int
+}
+
+func newDropTracer(label string) *dropTracer {
+	return &dropTracer{label: label, rejected: make(map[string]int)}
+}
+
+func (d *dropTracer) report() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return fmt.Sprintf("[%s] delivered=%d dup=%d grafts=%d dropRPC=%d undeliverable=%d throttled=%d rejected=%v",
+		d.label, d.delivered, d.duplicates, d.grafts, d.dropRPC, d.undeliverable, d.throttled, d.rejected)
+}
+
+// lossy reports whether any event implying actual message loss was traced.
+// RejectValidationIgnored is excluded: it is the seqno validator ignoring an
+// out-of-order older message whose newer sibling was already accepted.
+func (d *dropTracer) lossy() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dropRPC > 0 || d.undeliverable > 0 || d.throttled > 0 {
+		return true
+	}
+	for reason := range d.rejected {
+		if reason != pubsub.RejectValidationIgnored {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *dropTracer) AddPeer(peer.ID, protocol.ID) {}
+func (d *dropTracer) RemovePeer(peer.ID)           {}
+func (d *dropTracer) Join(string)                  {}
+func (d *dropTracer) Leave(string)                 {}
+func (d *dropTracer) Graft(peer.ID, string)        { d.mu.Lock(); d.grafts++; d.mu.Unlock() }
+func (d *dropTracer) Prune(peer.ID, string)        {}
+func (d *dropTracer) ValidateMessage(*pubsub.Message) {
+}
+func (d *dropTracer) DeliverMessage(*pubsub.Message) { d.mu.Lock(); d.delivered++; d.mu.Unlock() }
+func (d *dropTracer) RejectMessage(_ *pubsub.Message, reason string) {
+	d.mu.Lock()
+	d.rejected[reason]++
+	d.mu.Unlock()
+}
+func (d *dropTracer) DuplicateMessage(*pubsub.Message) { d.mu.Lock(); d.duplicates++; d.mu.Unlock() }
+func (d *dropTracer) ThrottlePeer(peer.ID)             { d.mu.Lock(); d.throttled++; d.mu.Unlock() }
+func (d *dropTracer) RecvRPC(*pubsub.RPC)              {}
+func (d *dropTracer) SendRPC(*pubsub.RPC, peer.ID)     {}
+func (d *dropTracer) DropRPC(_ *pubsub.RPC, p peer.ID) { d.mu.Lock(); d.dropRPC++; d.mu.Unlock() }
+func (d *dropTracer) UndeliverableMessage(*pubsub.Message) {
+	d.mu.Lock()
+	d.undeliverable++
+	d.mu.Unlock()
+}
+
+// memSeqnoStore mirrors kubo's seqnoStore (repo-datastore-backed) with a plain
+// map; the test repos use a fresh in-memory datastore anyway.
+type memSeqnoStore struct {
+	mu sync.Mutex
+	m  map[peer.ID][]byte
+}
+
+func (s *memSeqnoStore) Get(_ context.Context, p peer.ID) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.m[p], nil
+}
+
+func (s *memSeqnoStore) Put(_ context.Context, p peer.ID, val []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[p] = val
+	return nil
+}
+
+// testingTracedPubSub replaces the kubo node's internal pubsub with one we
+// construct ourselves: same options kubo uses (flood-publish +
+// BasicSeqnoValidator), plus a RawTracer and configurable queue sizes.
+// Must be called on a node built with pubsub disabled, before the core API
+// is created.
+func testingTracedPubSub(ctx context.Context, t *testing.T, node *ipfsCore.IpfsNode, label string, queueSize int) *dropTracer {
+	t.Helper()
+
+	tracer := newDropTracer(label)
+	ps, err := pubsub.NewGossipSub(ctx, node.PeerHost,
+		pubsub.WithFloodPublish(true),
+		pubsub.WithDefaultValidator(pubsub.NewBasicSeqnoValidator(&memSeqnoStore{m: make(map[peer.ID][]byte)}, slog.New(slog.DiscardHandler))),
+		pubsub.WithValidateQueueSize(queueSize),
+		pubsub.WithPeerOutboundQueueSize(queueSize),
+		pubsub.WithRawTracer(tracer),
+	)
+	require.NoError(t, err)
+
+	node.PubSub = ps
+
+	t.Cleanup(func() {
+		if tracer.lossy() {
+			fmt.Println("PUBSUB-TRACE", tracer.report())
+		}
+	})
+
+	return tracer
+}
+
+func testingTracedIPFSNode(ctx context.Context, t *testing.T, mn mocknet.Mocknet, label string, queueSize int) (*ipfsCore.IpfsNode, func()) {
+	t.Helper()
+
+	node, clean := testingIPFSNodeWithoutPubsub(ctx, t, mn)
+	_ = testingTracedPubSub(ctx, t, node, label, queueSize)
+	return node, clean
+}

--- a/tests/replicate_automatically_test.go
+++ b/tests/replicate_automatically_test.go
@@ -257,6 +257,12 @@ func TestReplicateAutomatically(t *testing.T) {
 			}, time.Second*20, time.Millisecond*50, "store did not discover topic peer")
 		}
 
+		// Peers() reports only received SUBSCRIBEs, not gossipsub mesh membership
+		// (which has no public API). Once the subscriptions have propagated, give
+		// the mesh a heartbeat (~1s) to GRAFT before writing: a head announced to
+		// an ungrafted mesh is silently dropped and never re-announced.
+		time.Sleep(2 * time.Second)
+
 		subCtx, subCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer subCancel()
 

--- a/tests/replicate_automatically_test.go
+++ b/tests/replicate_automatically_test.go
@@ -46,9 +46,13 @@ func TestReplicateAutomatically(t *testing.T) {
 
 		mocknet = testingMockNet(t)
 
+		// Build the nodes' pubsub ourselves with enlarged queues: kubo's default
+		// 32-slot queues silently drop head announcements under load, and with
+		// only two peers a dropped announcement has no gossip repair path (IHAVE
+		// is only sent to non-mesh peers). See pubsub_traced_test.go.
 		var node1Clean, node2Clean func()
-		node1, node1Clean = testingIPFSNode(ctx, t, mocknet)
-		node2, node2Clean = testingIPFSNode(ctx, t, mocknet)
+		node1, node1Clean = testingTracedIPFSNode(ctx, t, mocknet, "auto-node1", testPubsubQueueSize())
+		node2, node2Clean = testingTracedIPFSNode(ctx, t, mocknet, "auto-node2", testPubsubQueueSize())
 
 		ipfs1 := testingCoreAPI(t, node1)
 		ipfs2 := testingCoreAPI(t, node2)
@@ -257,13 +261,11 @@ func TestReplicateAutomatically(t *testing.T) {
 			}, time.Second*20, time.Millisecond*50, "store did not discover topic peer")
 		}
 
-		// Peers() reports only received SUBSCRIBEs, not gossipsub mesh membership
-		// (which has no public API). Once the subscriptions have propagated, give
-		// the mesh a heartbeat (~1s) to GRAFT before writing: a head announced to
-		// an ungrafted mesh is silently dropped and never re-announced.
-		time.Sleep(2 * time.Second)
-
-		subCtx, subCancel := context.WithTimeout(ctx, 5*time.Second)
+		// The receive loop below exits as soon as db2 has caught up, so this
+		// budget is only consumed on failure. Under -race -cover with the whole
+		// suite contending for CPU on CI runners, 5s proved too tight (the
+		// sibling reconnect subtest was observed needing ~23s for similar work).
+		subCtx, subCancel := context.WithTimeout(ctx, 60*time.Second)
 		defer subCancel()
 
 		sub2, err := db2.EventBus().Subscribe([]interface{}{

--- a/tests/replicate_automatically_test.go
+++ b/tests/replicate_automatically_test.go
@@ -143,7 +143,13 @@ func TestReplicateAutomatically(t *testing.T) {
 		require.NoError(t, err)
 		defer sub.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		// Replication here runs the full reconnect path: the peers rejoin the
+		// topic, exchange heads, then db2 fetches the 10 entries over bitswap.
+		// That chain is inherently slow and, under -race -cover with the whole
+		// suite contending for CPU on CI runners, occasionally creeps past a
+		// tighter budget (observed ~23s). Give it generous headroom; the loop
+		// below still fails fast on a genuine stall rather than spinning.
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
 		centries := make(chan cid.Cid, entryCount)

--- a/tests/replicate_test.go
+++ b/tests/replicate_test.go
@@ -398,7 +398,10 @@ func testDirectChannelNodeGenerator(t *testing.T, mn mocknet.Mocknet, i int) (or
 	dbPath1, clean := testingTempDir(t, fmt.Sprintf("db%d", i))
 	closeOps = append(closeOps, clean)
 
-	node1, clean := testingIPFSNode(ctx, t, mn)
+	// Build the node's pubsub ourselves with enlarged queues: kubo's default
+	// 32-slot queues silently drop head announcements during concurrent write
+	// bursts (see pubsub_traced_test.go).
+	node1, clean := testingTracedIPFSNode(ctx, t, mn, fmt.Sprintf("direct-channel-node%d", i), testPubsubQueueSize())
 	closeOps = append(closeOps, clean)
 
 	// logger, _ := zap.NewDevelopment()
@@ -440,7 +443,10 @@ func testDefaultNodeGenerator(t *testing.T, mn mocknet.Mocknet, i int) (orbitdb.
 	dbPath1, clean := testingTempDir(t, fmt.Sprintf("db%d", i))
 	closeOps = append(closeOps, clean)
 
-	node1, clean := testingIPFSNode(ctx, t, mn)
+	// Build the node's pubsub ourselves with enlarged queues: kubo's default
+	// 32-slot queues silently drop head announcements during concurrent write
+	// bursts (see pubsub_traced_test.go).
+	node1, clean := testingTracedIPFSNode(ctx, t, mn, fmt.Sprintf("default-node%d", i), testPubsubQueueSize())
 	closeOps = append(closeOps, clean)
 
 	ipfs1 := testingCoreAPI(t, node1)


### PR DESCRIPTION
Fixes the remaining replication test flakes on master. Test-side only, no production code changes.

## Root cause

By attaching a `RawTracer` to pubsub, the flakes were traced to go-libp2p-pubsub's default 32-slot per-peer outbound queues: during write bursts, whole RPCs are silently dropped (`DropRPC`) and published messages are never retried. A head announcement that loses all redundant paths (flood-publish, mesh forwarding, the ~3s IHAVE/IWANT gossip window) is never replicated. With only 2 peers it's worse: IHAVE is only sent to non-mesh peers, so a dropped announcement has no repair path at all.

Kubo's internal pubsub can't be tuned or traced, so the tests now build the same gossipsub kubo would (flood-publish + `BasicSeqnoValidator`) with 256-slot queues and a tracer that prints drop counters when real loss occurs (`pubsub_traced_test.go`). `TEST_PUBSUB_QUEUE=32` reproduces the kubo-default behavior.

Measured on the flakiest case (10-peer `TestReplicationMultipeer`): queue 32 → 2 failures/15 runs, up to ~260 dropped RPCs per node; queue 256 → 30+/30 clean, zero drops.

## Changes

- **`replicate_test.go`**: node generators use the enlarged-queue pubsub.
- **`replicate_automatically_test.go`**: same pubsub for both nodes; reconnect subtest budget 20s → 60s and exchange-heads subtest budget 5s → 60s (both observed too tight under `-race -cover` on CI runners; the budgets are only consumed on failure, the wait loops exit as soon as replication completes).
