### PR TITLE
fix(pubsub): recover replication after pubsub connect/disconnect race

### DIFF
--- a/pubsub/pubsubcoreapi/pubsub.go
+++ b/pubsub/pubsubcoreapi/pubsub.go
@@ -17,11 +17,26 @@ import (
 	"berty.tech/go-orbit-db/pubsub"
 )
 
+// DefaultRecoverGracePolls is how many consecutive WatchPeers polls a peer must
+// be observed as libp2p-connected-but-absent from the topic before it is
+// reconciled back in. It guards against the normal connect/subscribe window
+// (where a freshly connected peer briefly isn't in the topic yet) while still
+// recovering from the go-libp2p-pubsub connect/disconnect race quickly.
+const DefaultRecoverGracePolls = 3
+
 type psTopic struct {
 	topic     string
 	ps        *coreAPIPubSub
 	members   []peer.ID
 	muMembers sync.RWMutex
+
+	// knownMembers are peers that have been seen subscribed to this topic at
+	// least once. Only these are eligible for connectedness reconciliation, so
+	// we never resurrect peers that were never part of the topic.
+	knownMembers map[peer.ID]struct{}
+	// absentCounts tracks, per known-and-still-connected peer, how many
+	// consecutive polls it has been missing from the topic.
+	absentCounts map[peer.ID]int
 }
 
 func (p *psTopic) Publish(ctx context.Context, message []byte) error {
@@ -45,10 +60,12 @@ func (p *psTopic) peersDiff(ctx context.Context) (joining, leaving []peer.ID, er
 	}
 	p.muMembers.RUnlock()
 
-	all, err := p.ps.api.PubSub().Peers(ctx, options.PubSub.Topic(p.topic))
+	topicMembers, err := p.ps.topicPeers(ctx, p.topic)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	all := p.reconcile(ctx, topicMembers)
 
 	for _, m := range all {
 		if _, ok := oldMembers[m]; !ok {
@@ -67,6 +84,68 @@ func (p *psTopic) peersDiff(ctx context.Context) (joining, leaving []peer.ID, er
 	p.muMembers.Unlock()
 
 	return joining, leaving, nil
+}
+
+// reconcile augments the set of pubsub topic members with peers that are still
+// connected at the libp2p level but have silently fallen out of the topic.
+//
+// This works around a go-libp2p-pubsub connect/disconnect race: when a peer
+// disconnects and reconnects quickly, pubsub can process the new-connection
+// event before the matching disconnect event, dedupe the reconnecting peer
+// against its own stale entry, and never re-propagate its subscription. The
+// libp2p connection is healthy but the peer ends up listed in zero topics, so
+// no PeerJoin ever fires and the store never re-triggers exchangeHeads — the
+// reconnected peer can never catch up.
+//
+// We detect such peers (previously seen in this topic, still connected, absent
+// for more than DefaultRecoverGracePolls polls) and treat them as members
+// again. That re-emits a PeerJoin, which resumes head exchange over the direct
+// channel — independent of whether pubsub itself ever heals the subscription.
+func (p *psTopic) reconcile(ctx context.Context, topicMembers []peer.ID) []peer.ID {
+	inTopic := make(map[peer.ID]struct{}, len(topicMembers))
+	for _, m := range topicMembers {
+		inTopic[m] = struct{}{}
+		p.knownMembers[m] = struct{}{}
+		delete(p.absentCounts, m)
+	}
+
+	// recoverGracePolls <= 0 disables reconciliation and preserves the legacy
+	// behaviour of trusting the pubsub topic membership verbatim.
+	if p.ps.recoverGracePolls <= 0 {
+		return topicMembers
+	}
+
+	connected := p.ps.connectedPeers(ctx)
+	connectedSet := make(map[peer.ID]struct{}, len(connected))
+
+	effective := append([]peer.ID(nil), topicMembers...)
+	for _, pid := range connected {
+		connectedSet[pid] = struct{}{}
+
+		if _, ok := inTopic[pid]; ok {
+			continue
+		}
+
+		if _, known := p.knownMembers[pid]; !known {
+			// never part of this topic: not a lost subscription, ignore it.
+			continue
+		}
+
+		p.absentCounts[pid]++
+		if p.absentCounts[pid] >= p.ps.recoverGracePolls {
+			effective = append(effective, pid)
+		}
+	}
+
+	// Forget absence bookkeeping for peers that are no longer connected; a real
+	// PeerLeave is emitted for them through the normal diff.
+	for pid := range p.absentCounts {
+		if _, ok := connectedSet[pid]; !ok {
+			delete(p.absentCounts, pid)
+		}
+	}
+
+	return effective
 }
 
 func (p *psTopic) WatchPeers(ctx context.Context) (<-chan events.Event, error) {
@@ -149,6 +228,36 @@ type coreAPIPubSub struct {
 	tracer       trace.Tracer
 	topics       map[string]*psTopic
 	muTopics     sync.Mutex
+
+	// recoverGracePolls drives the connectedness-based reconciliation in
+	// psTopic.reconcile (see DefaultRecoverGracePolls). 0 disables it.
+	recoverGracePolls int
+
+	// topicPeers returns the peers pubsub currently lists for a topic, and
+	// connectedPeers returns the peers we are connected to at the libp2p level.
+	// They are fields so tests can drive the reconnect race deterministically
+	// without a real IPFS node; in production they wrap the CoreAPI.
+	topicPeers     func(ctx context.Context, topic string) ([]peer.ID, error)
+	connectedPeers func(ctx context.Context) []peer.ID
+}
+
+func (c *coreAPIPubSub) defaultTopicPeers(ctx context.Context, topic string) ([]peer.ID, error) {
+	return c.api.PubSub().Peers(ctx, options.PubSub.Topic(topic))
+}
+
+func (c *coreAPIPubSub) defaultConnectedPeers(ctx context.Context) []peer.ID {
+	conns, err := c.api.Swarm().Peers(ctx)
+	if err != nil {
+		c.logger.Debug("unable to list swarm peers for reconciliation", zap.Error(err))
+		return nil
+	}
+
+	ids := make([]peer.ID, len(conns))
+	for i, conn := range conns {
+		ids[i] = conn.ID()
+	}
+
+	return ids
 }
 
 func (c *coreAPIPubSub) TopicSubscribe(_ context.Context, topic string) (iface.PubSubTopic, error) {
@@ -160,8 +269,10 @@ func (c *coreAPIPubSub) TopicSubscribe(_ context.Context, topic string) (iface.P
 	}
 
 	c.topics[topic] = &psTopic{
-		topic: topic,
-		ps:    c,
+		topic:        topic,
+		ps:           c,
+		knownMembers: map[peer.ID]struct{}{},
+		absentCounts: map[peer.ID]int{},
 	}
 
 	return c.topics[topic], nil
@@ -176,14 +287,20 @@ func NewPubSub(api coreiface.CoreAPI, id peer.ID, pollInterval time.Duration, lo
 		tracer = tracenoop.NewTracerProvider().Tracer("")
 	}
 
-	return &coreAPIPubSub{
-		topics:       map[string]*psTopic{},
-		api:          api,
-		id:           id,
-		logger:       logger,
-		pollInterval: pollInterval,
-		tracer:       tracer,
+	c := &coreAPIPubSub{
+		topics:            map[string]*psTopic{},
+		api:               api,
+		id:                id,
+		logger:            logger,
+		pollInterval:      pollInterval,
+		tracer:            tracer,
+		recoverGracePolls: DefaultRecoverGracePolls,
 	}
+
+	c.topicPeers = c.defaultTopicPeers
+	c.connectedPeers = c.defaultConnectedPeers
+
+	return c
 }
 
 var _ iface.PubSubInterface = &coreAPIPubSub{}

--- a/pubsub/pubsubcoreapi/pubsub_reconnect_test.go
+++ b/pubsub/pubsubcoreapi/pubsub_reconnect_test.go
@@ -1,0 +1,198 @@
+package pubsubcoreapi
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap"
+
+	"berty.tech/go-orbit-db/iface"
+)
+
+// Phases of the go-libp2p-pubsub connect/disconnect race, as observed from the
+// receiver's perspective on a shared topic:
+//
+//   - phaseMember : the peer is a healthy topic member (connected + in topic).
+//   - phaseOffline: the peer disconnects (gone from both the topic and libp2p).
+//   - phaseStuck  : the peer reconnects *at the libp2p level* but, because of
+//     the pubsub connect/disconnect race, its subscription is never
+//     re-propagated. The libp2p connection is healthy yet the peer is listed in
+//     zero topics. No PeerJoin ever fires, so the store never re-triggers
+//     exchangeHeads and the reconnected peer can never catch up.
+const (
+	phaseMember = iota
+	phaseOffline
+	phaseStuck
+)
+
+// newPhasedPubSub builds a coreAPIPubSub whose view of the world is driven by a
+// single atomic "phase" instead of a real IPFS node, so the race is fully
+// deterministic. topicPeers models pubsub topic membership; connectedPeers
+// models libp2p connectedness. In phaseStuck the peer is connected but missing
+// from the topic, exactly reproducing the lost-subscription bug.
+func newPhasedPubSub(grace int, peerA peer.ID, phase *atomic.Int32) *coreAPIPubSub {
+	c := &coreAPIPubSub{
+		topics:            map[string]*psTopic{},
+		id:                peer.ID("self"),
+		pollInterval:      2 * time.Millisecond,
+		logger:            zap.NewNop(),
+		tracer:            tracenoop.NewTracerProvider().Tracer(""),
+		recoverGracePolls: grace,
+	}
+
+	c.topicPeers = func(_ context.Context, _ string) ([]peer.ID, error) {
+		if phase.Load() == phaseMember {
+			return []peer.ID{peerA}, nil
+		}
+		// Offline: genuinely gone. Stuck: silently dropped from the topic
+		// while the libp2p connection stays up (the bug).
+		return nil, nil
+	}
+
+	c.connectedPeers = func(_ context.Context) []peer.ID {
+		switch phase.Load() {
+		case phaseMember, phaseStuck:
+			return []peer.ID{peerA}
+		default: // phaseOffline
+			return nil
+		}
+	}
+
+	return c
+}
+
+// expectJoin waits for a PeerJoin for peerA within timeout.
+func expectJoin(t *testing.T, ch <-chan eventsEvent, peerA peer.ID, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case e := <-ch:
+			if j, ok := e.(*iface.EventPubSubJoin); ok && j.Peer == peerA {
+				return
+			}
+			// ignore other events (e.g. a leave) and keep waiting
+		case <-deadline:
+			t.Fatalf("timed out waiting for PeerJoin of %s", peerA)
+		}
+	}
+}
+
+// expectLeave waits for a PeerLeave for peerA within timeout.
+func expectLeave(t *testing.T, ch <-chan eventsEvent, peerA peer.ID, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case e := <-ch:
+			if l, ok := e.(*iface.EventPubSubLeave); ok && l.Peer == peerA {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for PeerLeave of %s", peerA)
+		}
+	}
+}
+
+// expectNoJoin asserts that no PeerJoin for peerA arrives within the window.
+func expectNoJoin(t *testing.T, ch <-chan eventsEvent, peerA peer.ID, window time.Duration) {
+	t.Helper()
+	deadline := time.After(window)
+	for {
+		select {
+		case e := <-ch:
+			if j, ok := e.(*iface.EventPubSubJoin); ok && j.Peer == peerA {
+				t.Fatalf("unexpected PeerJoin of %s while reconciliation disabled", peerA)
+			}
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// eventsEvent is the element type emitted on the WatchPeers channel.
+type eventsEvent = interface{}
+
+// runPhases drives a single psTopic through member -> offline -> stuck and
+// returns the channel so the caller can assert on the phaseStuck behaviour.
+func runPhases(t *testing.T, ps *coreAPIPubSub, peerA peer.ID, phase *atomic.Int32) <-chan eventsEvent {
+	t.Helper()
+
+	topic, err := ps.TopicSubscribe(context.Background(), "store-addr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := topic.WatchPeers(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// adapt the typed channel to interface{}
+	ch := make(chan eventsEvent, 32)
+	go func() {
+		for e := range raw {
+			ch <- e
+		}
+		close(ch)
+	}()
+
+	// phaseMember: the peer is a healthy member -> a join is emitted.
+	expectJoin(t, ch, peerA, time.Second)
+
+	// phaseOffline: the peer disconnects -> a leave is emitted.
+	phase.Store(phaseOffline)
+	expectLeave(t, ch, peerA, time.Second)
+
+	// phaseStuck: the peer reconnects at the libp2p level but its subscription
+	// is silently lost (the race). From now on it is connected-but-not-in-topic.
+	phase.Store(phaseStuck)
+
+	return ch
+}
+
+// TestReconnectRaceReplicationRecovery reproduces the go-orbit-db replication
+// stall caused by the go-libp2p-pubsub connect/disconnect race, and asserts
+// that the connectedness-based reconciliation recovers from it.
+//
+// The two subtests share the exact same scenario; the only difference is
+// whether reconciliation is enabled (recoverGracePolls > 0):
+//
+//   - "issue": with reconciliation disabled (the pre-fix behaviour), the stuck
+//     peer never rejoins the topic, so no PeerJoin fires and the store would
+//     never re-trigger exchangeHeads -> the reconnected peer is stuck forever.
+//   - "fix": with reconciliation enabled, the still-connected peer is detected
+//     and re-emitted as a member, so a PeerJoin fires and head exchange resumes.
+func TestReconnectRaceReplicationRecovery(t *testing.T) {
+	peerA := peer.ID("peer-A")
+
+	t.Run("issue: stuck peer never recovers without reconciliation", func(t *testing.T) {
+		var phase atomic.Int32
+		phase.Store(phaseMember)
+
+		ps := newPhasedPubSub(0 /* reconciliation disabled */, peerA, &phase)
+		ch := runPhases(t, ps, peerA, &phase)
+
+		// The peer is connected but absent from the topic. Pre-fix, nothing
+		// ever re-triggers it: assert no PeerJoin arrives. We wait a full
+		// second (as in expectJoin) to be confident the peer truly never
+		// rejoins, rather than just not yet.
+		expectNoJoin(t, ch, peerA, time.Second)
+	})
+
+	t.Run("fix: stuck peer recovers via connectedness reconciliation", func(t *testing.T) {
+		var phase atomic.Int32
+		phase.Store(phaseMember)
+
+		ps := newPhasedPubSub(3 /* reconciliation enabled */, peerA, &phase)
+		ch := runPhases(t, ps, peerA, &phase)
+
+		// The still-connected peer is reconciled back into the topic, so a
+		// fresh PeerJoin fires and exchangeHeads can resume.
+		expectJoin(t, ch, peerA, time.Second)
+	})
+}


### PR DESCRIPTION
## Problem

On a fast disconnect→reconnect, `go-libp2p-pubsub` can process the **new-connection** event before the matching **disconnect** event for the same peer. The new-peer handler dedupes against the still-present stale peer entry and **skips re-registering the peer**, so the reconnecting peer's subscription is never re-propagated.

The result: the libp2p connection is healthy, but the peer ends up listed in **zero topics**. In go-orbit-db, `psTopic.WatchPeers` derives `PeerJoin` events purely from `PubSub().Peers(topic)`, so no `PeerJoin` ever fires → `onNewPeerJoined`/`exchangeHeads` is never re-triggered → the reconnected peer can never catch up. The only recovery today is a *fresh* reconnection (continuous discovery/backoff redial in real deployments), which is why downstream tests need reconnect-retry loops.

This is an upstream `go-libp2p-pubsub` race (reproduced on v0.15.0), but go-orbit-db can recover from it on its own.

## Fix

`psTopic.peersDiff` now reconciles pubsub topic membership against **libp2p connectedness** (`api.Swarm().Peers`). A peer that:

- was a **known former member** of this topic,
- is **still libp2p-connected**, and
- has been **absent from the topic for ≥ `DefaultRecoverGracePolls` polls**

is treated as a member again, re-emitting a `PeerJoin`. That resumes head exchange **over the direct channel** (`exchangeHeads` uses `directChannel`, not pubsub), so replication recovers independently of whether pubsub ever heals the subscription.

Key points:
- Scoped to *known former members*, so peers that were never part of the topic are never resurrected.
- The grace period guards against the normal connect/subscribe window (a freshly connected peer is briefly not in the topic yet).
- `recoverGracePolls = 0` preserves the exact legacy behavior.
- Known benign false positive: a peer that legitimately unsubscribes while staying connected gets one wasted (idempotent) `exchangeHeads`.

## Test

`TestReconnectRaceReplicationRecovery` is a deterministic white-box test (no real IPFS node, no flaky 1/100 reproduction). It drives a `psTopic` through `member → offline → stuck` phases via injected `topicPeers`/`connectedPeers` seams, where `stuck` = connected-but-absent-from-topic (the race). Two subtests share the scenario:

- **issue** (reconciliation disabled): asserts the peer stays stuck — no `PeerJoin` ever fires.
- **fix** (reconciliation enabled): asserts the peer is reconciled back and a `PeerJoin` fires.

Verified: passes under `-race` repeatedly; live-node `TestReplication` and `TestReplicationMultipeer` still pass.