### PR TITLE
ci: replace blocked semantic-release action with npx run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,14 @@ jobs:
   semantic-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: codfish/semantic-release-action@v1
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Run semantic-release
         if: github.ref == 'refs/heads/master'
+        run: npx --yes semantic-release@24
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    branch: 'master',
+    branches: ['master'],
     plugins: [
         '@semantic-release/commit-analyzer',
         '@semantic-release/release-notes-generator',


### PR DESCRIPTION
## Problem

Every push to `master` since 2026-06-25 fails the Release workflow, e.g. [run 29073201024](https://github.com/berty/go-orbit-db/actions/runs/29073201024/job/86298964946):

```
Getting action download info
##[error]Repository access blocked
```

The job dies before any step runs. The cause is that `codfish/semantic-release-action` was blocked by GitHub for a ToS violation:

```
$ gh api repos/codfish/semantic-release-action
{"message":"Repository access blocked","block":{"reason":"tos","created_at":"2026-06-25T15:04:22Z"}}
```

The timeline matches: the last successful release was v1.22.2 on 2026-06-03, and everything after the block date fails identically. Nothing can be done on our side to make that action resolvable again.

## Fix

Run `semantic-release` directly rather than through a third-party wrapper action. The three plugins configured in `.releaserc.js` (`commit-analyzer`, `release-notes-generator`, `github`) all ship with `semantic-release` itself, so no extra install step is needed.

Supporting changes:

- `fetch-depth: 0` on checkout — semantic-release needs the full history and tags to determine the last release.
- `.releaserc.js`: `branch: 'master'` → `branches: ['master']`. The singular `branch` option was removed in semantic-release v16 and is rejected by current versions.
- Pin `actions/checkout` to a tag instead of the floating `@master` ref.

## Verification

Dry run against a clone of the repo with a real token:

```
[semantic-release] › ℹ  Running semantic-release version 24.2.9
[semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
...
[@semantic-release/commit-analyzer] › ℹ  Analysis of 14 commits complete: no release
[semantic-release] › ℹ  There are no relevant changes, so no new version is released.
```

Plugins load and verify, the branch config is recognised, the last release is detected, and the 14 commits since it are analysed correctly (all `chore`/`test`, hence no release).